### PR TITLE
adds default case for resource

### DIFF
--- a/lib/authorizer/resource.rb
+++ b/lib/authorizer/resource.rb
@@ -55,6 +55,8 @@ module ActionAuthorization
               collect_permitted {|results| results.length == @resources.length}
           when :filter
               collect_permitted {|results| results.length > 0}
+          else
+            collect_permitted {|results| results.length > 0}
           end
         end
   


### PR DESCRIPTION
Patches a bug where passing an unrecoginzed `behavior` to `check_authorization` with a list could result in authorizing resources without checking whether they passed the authorization check.